### PR TITLE
FIX : 프런트엔드 연동을 위한 웹알티씨 연결 규칙변경 

### DIFF
--- a/app/src/main/java/example/beechang/together/ui/call/room/CallSignallingViewModel.kt
+++ b/app/src/main/java/example/beechang/together/ui/call/room/CallSignallingViewModel.kt
@@ -300,7 +300,8 @@ class CallSignallingViewModel @Inject constructor(
             if (it.value.userId != currentState.myUserId) {
                 webRtcManager.processAction(
                     CreatePeerConnection(
-                        userId = it.value.userId,
+                        localUserId = currentState.myUserId,
+                        remoteUserId = it.value.userId,
                         role = PeerConnectionRole.Answerer
                     )
                 )
@@ -320,7 +321,8 @@ class CallSignallingViewModel @Inject constructor(
                     viewModelScope.launch {
                         webRtcManager.processActionAsync(
                             CreatePeerConnection(
-                                userId = res.userId,
+                                localUserId = currentState.myUserId,
+                                remoteUserId = res.userId,
                                 role = PeerConnectionRole.Offerer
                             )
                         )

--- a/app/src/main/java/example/beechang/together/webrtc/DefaultTogeWebRtcManager.kt
+++ b/app/src/main/java/example/beechang/together/webrtc/DefaultTogeWebRtcManager.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -398,11 +399,9 @@ class DefaultTogeWebRtcManager @Inject constructor(
     }
 
     private fun setRemoteDescription(remoteUserId: String, sdp: String, isOffer: Boolean) {
-        remoteUserPeerConnection[remoteUserId]?.setRemoteDescription(
-            sdp = sdp,
-            isOffer = isOffer
-        )
-        applyPendingIceCandidates(remoteUserId)
+        remoteUserPeerConnection[remoteUserId]?.setRemoteDescription(sdp = sdp, isOffer = isOffer) {
+            applyPendingIceCandidates(remoteUserId)
+        }
     }
 
     private fun applyPendingIceCandidates(userId: String) {

--- a/app/src/main/java/example/beechang/together/webrtc/DefaultTogeWebRtcManager.kt
+++ b/app/src/main/java/example/beechang/together/webrtc/DefaultTogeWebRtcManager.kt
@@ -87,7 +87,8 @@ class DefaultTogeWebRtcManager @Inject constructor(
 
             is WebRtcAction.General.CreatePeerConnection -> {
                 createPeerConnection(
-                    remoteUserId = action.userId,
+                    localUserId = action.localUserId,
+                    remoteUserId = action.remoteUserId,
                     role = action.role
                 )
             }
@@ -186,9 +187,15 @@ class DefaultTogeWebRtcManager @Inject constructor(
         }
     }
 
-    private fun createPeerConnection(remoteUserId: String, role: PeerConnectionRole) {
+    private fun createPeerConnection(
+        localUserId: String,
+        remoteUserId: String,
+        role: PeerConnectionRole
+    ) {
         val togePC = TogePeerConnection(
             pcf = pcf.pcf,
+            localUserId = localUserId,
+            remoteUserId = remoteUserId,
             updatedVideoTrack = { track ->
                 updateParticipant(remoteUserId) { participant -> participant.copy(videoTrack = track) }
                 setupVideoTrackResolutionObserver(track, remoteUserId)

--- a/app/src/main/java/example/beechang/together/webrtc/TogeWebRtcManager.kt
+++ b/app/src/main/java/example/beechang/together/webrtc/TogeWebRtcManager.kt
@@ -55,7 +55,12 @@ sealed interface WebRtcAction {
 
     sealed interface General : WebRtcAction {
         data class InitWebRtc(val userId: String) : General
-        data class CreatePeerConnection(val userId: String, val role: PeerConnectionRole) : General
+        data class CreatePeerConnection(
+            val localUserId: String,
+            val remoteUserId: String,
+            val role: PeerConnectionRole
+        ) : General
+
         data class SwitchCamera(val userId: String) : General
         data class RemoveParticipant(val userId: String) : General
         data class ToggleVideo(val userId: String, val enabled: Boolean) : General

--- a/app/src/main/java/example/beechang/together/webrtc/peerconnection/TogePeerConnection.kt
+++ b/app/src/main/java/example/beechang/together/webrtc/peerconnection/TogePeerConnection.kt
@@ -17,6 +17,8 @@ import org.webrtc.VideoTrack
 
 class TogePeerConnection(
     private val pcf: PeerConnectionFactory,
+    private val localUserId: String,
+    private val remoteUserId: String,
     private val updatedVideoTrack: (VideoTrack) -> Unit,
     private val updatedAudioTrack: (AudioTrack) -> Unit,
     private val emitIceCandidate: (String/*sdp*/, String/*sdpMid*/, Int/*sdpMLineIndex*/) -> Unit,
@@ -34,6 +36,9 @@ class TogePeerConnection(
     private val turnServerUsername: String = BuildConfig.TURN_SERVER_USERNAME
     private val turnServerPassword: String = BuildConfig.TURN_SERVER_PASSWORD
 
+    private var makingOffer = false
+    private var ignoreOffer = false
+    private val isPolite = localUserId > remoteUserId
 
     private val iceTurnServer: List<PeerConnection.IceServer> by lazy {
         buildList {

--- a/app/src/main/java/example/beechang/together/webrtc/peerconnection/TogePeerConnection.kt
+++ b/app/src/main/java/example/beechang/together/webrtc/peerconnection/TogePeerConnection.kt
@@ -87,14 +87,15 @@ class TogePeerConnection(
     fun createAnswer() {
         peerConnection.createAnswer(
             sdpObserver(
-            onCreateSuccess = {
-                it?.let { sessionDescription ->
-                    val description = it.description
-                    answer = it
-                    setLocalDescription(sdp = description, isOffer = false)
-                    sendAnswer.invoke(description)
-                }
-            }), constraints)
+                onCreateSuccess = {
+                    it?.let { sessionDescription ->
+                        val description = it.description
+                        answer = it
+                        setLocalDescription(sdp = description, isOffer = false)
+                        sendAnswer.invoke(description)
+                    }
+                }), constraints
+        )
     }
 
     fun createOffer() {
@@ -102,16 +103,17 @@ class TogePeerConnection(
         peerConnection.createOffer(
             sdpObserver(
                 onCreateSuccess = {
-            it?.let { sessionDescription ->
-                val description = sessionDescription.description
-                offer = sessionDescription
-                setLocalDescription(sdp = description, isOffer = true)
-                sendOffer.invoke(description)
-            }
-        },
-            onSetSuccess = { makingOffer = false },
-            onCreateFailure = { error -> makingOffer = false },
-            onSetFailure = { error -> makingOffer = false }), constraints)
+                    it?.let { sessionDescription ->
+                        val description = sessionDescription.description
+                        offer = sessionDescription
+                        setLocalDescription(sdp = description, isOffer = true)
+                        sendOffer.invoke(description)
+                    }
+                },
+                onSetSuccess = { makingOffer = false },
+                onCreateFailure = { error -> makingOffer = false },
+                onSetFailure = { error -> makingOffer = false }), constraints
+        )
     }
 
     fun setLocalDescription(sdp: String, isOffer: Boolean) {
@@ -121,7 +123,7 @@ class TogePeerConnection(
         peerConnection.setLocalDescription(sdpObserver(), sessionDescription)
     }
 
-    fun setRemoteDescription(sdp: String, isOffer: Boolean) {
+    fun setRemoteDescription(sdp: String, isOffer: Boolean, onSetSuccess: () -> Unit = {}) {
         if (isOffer) {
             val offerCollision =
                 peerConnection.signalingState() != SignalingState.STABLE || makingOffer
@@ -134,11 +136,12 @@ class TogePeerConnection(
             if (isPolite && offerCollision) {
                 peerConnection.setLocalDescription(
                     sdpObserver(onSetSuccess = {
-                    makingOffer = false
-                    setRemoteOfferAfterRollback(sdp)
-                }, onSetFailure = { res ->
-                    makingOffer = false
-                }), SessionDescription(SessionDescription.Type.ROLLBACK, ""))
+                        makingOffer = false
+                        setRemoteOfferAfterRollback(sdp)
+                    }, onSetFailure = { res ->
+                        makingOffer = false
+                    }), SessionDescription(SessionDescription.Type.ROLLBACK, "")
+                )
                 return
             }
         }
@@ -150,6 +153,7 @@ class TogePeerConnection(
             sdpObserver(
                 onSetSuccess = {
                     isRemoteDescriptionSet = true
+                    onSetSuccess()
                 },
             ), sessionDescription
         )

--- a/app/src/main/java/example/beechang/together/webrtc/peerconnection/TogePeerConnection.kt
+++ b/app/src/main/java/example/beechang/together/webrtc/peerconnection/TogePeerConnection.kt
@@ -7,6 +7,7 @@ import org.webrtc.DataChannel
 import org.webrtc.IceCandidate
 import org.webrtc.MediaConstraints
 import org.webrtc.MediaStream
+import org.webrtc.MediaStreamTrack
 import org.webrtc.PeerConnection
 import org.webrtc.PeerConnection.SignalingState
 import org.webrtc.PeerConnectionFactory
@@ -29,6 +30,7 @@ class TogePeerConnection(
     private lateinit var peerConnection: PeerConnection
     private lateinit var offer: SessionDescription
     private lateinit var answer: SessionDescription
+    private val localStreamIdList: List<String> = listOf("${localUserId}_stream_id")
 
     private var isRemoteDescriptionSet: Boolean = false
 
@@ -75,13 +77,27 @@ class TogePeerConnection(
     }
 
     fun addLocalVideoTrack(localVideoTrack: VideoTrack? = null) {
-        localVideoTrack?.let {
-            peerConnection.addTrack(it)
+        localVideoTrack?.let { newTrack ->
+            val videoSender = peerConnection.senders
+                .find { it.track()?.kind() == MediaStreamTrack.VIDEO_TRACK_KIND }
+
+            when (videoSender) {
+                null -> peerConnection.addTrack(newTrack, localStreamIdList)
+                else -> videoSender.setTrack(newTrack, true) // track update
+            }
         }
     }
 
     fun addLocalAudioTrack(localAudioTrack: AudioTrack? = null) {
-        localAudioTrack?.let { peerConnection.addTrack(it) }
+        localAudioTrack?.let { newTrack ->
+            val audioSender = peerConnection.senders
+                .find { it.track()?.kind() == MediaStreamTrack.AUDIO_TRACK_KIND }
+
+            when (audioSender) {
+                null -> peerConnection.addTrack(newTrack, localStreamIdList) // add new audio track
+                else -> audioSender.setTrack(newTrack, true) // track update
+            }
+        }
     }
 
     fun createAnswer() {

--- a/app/src/main/java/example/beechang/together/webrtc/peerconnection/TogePeerConnection.kt
+++ b/app/src/main/java/example/beechang/together/webrtc/peerconnection/TogePeerConnection.kt
@@ -30,25 +30,22 @@ class TogePeerConnection(
     private lateinit var offer: SessionDescription
     private lateinit var answer: SessionDescription
 
-    private var isRemoteDiscriptionSet: Boolean = false
+    private var isRemoteDescriptionSet: Boolean = false
 
-    private val tunserver: String  = BuildConfig.TURN_SERVER_URL
+    private val tunserver: String = BuildConfig.TURN_SERVER_URL
     private val turnServerUsername: String = BuildConfig.TURN_SERVER_USERNAME
     private val turnServerPassword: String = BuildConfig.TURN_SERVER_PASSWORD
 
     private var makingOffer = false
-    private var ignoreOffer = false
     private val isPolite = localUserId > remoteUserId
 
     private val iceTurnServer: List<PeerConnection.IceServer> by lazy {
         buildList {
             add(PeerConnection.IceServer.builder("stun:stun4.l.google.com:19302").createIceServer())
-            if(tunserver.isNotEmpty() && turnServerUsername.isNotEmpty() && turnServerPassword.isNotEmpty()) {
+            if (tunserver.isNotEmpty() && turnServerUsername.isNotEmpty() && turnServerPassword.isNotEmpty()) {
                 add(
-                    PeerConnection.IceServer.builder(tunserver)
-                        .setUsername(turnServerUsername)
-                        .setPassword(turnServerPassword)
-                        .createIceServer()
+                    PeerConnection.IceServer.builder(tunserver).setUsername(turnServerUsername)
+                        .setPassword(turnServerPassword).createIceServer()
                 )
             }
         }
@@ -62,11 +59,11 @@ class TogePeerConnection(
 
     val constraints = MediaConstraints()
 
-    fun hasRemoteDescription(): Boolean = isRemoteDiscriptionSet
+    fun hasRemoteDescription(): Boolean = isRemoteDescriptionSet
 
     fun isFinishedOfferAnswerExchange(): Boolean {
         return if (this::peerConnection.isInitialized) {
-            peerConnection.signalingState() == SignalingState.STABLE && isRemoteDiscriptionSet
+            peerConnection.signalingState() == SignalingState.STABLE && isRemoteDescriptionSet
         } else {
             false
         }
@@ -89,57 +86,73 @@ class TogePeerConnection(
 
     fun createAnswer() {
         peerConnection.createAnswer(
-            object : SdpObserver {
-                override fun onCreateSuccess(sessionDescription: SessionDescription?) {
-                    sessionDescription?.let {
-                        val description = it.description
-                        answer = it
-                        setLocalDescription(sdp = description, isOffer = false)
-                        sendAnswer.invoke(description)
-                    }
+            sdpObserver(
+            onCreateSuccess = {
+                it?.let { sessionDescription ->
+                    val description = it.description
+                    answer = it
+                    setLocalDescription(sdp = description, isOffer = false)
+                    sendAnswer.invoke(description)
                 }
-
-                override fun onSetSuccess() {}
-                override fun onCreateFailure(p0: String?) {}
-                override fun onSetFailure(p0: String?) {}
-            }, constraints
-        )
+            }), constraints)
     }
 
     fun createOffer() {
+        makingOffer = true
         peerConnection.createOffer(
-            object : SdpObserver {
-                override fun onCreateSuccess(sessionDescription: SessionDescription?) {
-                    sessionDescription?.let {
-                        val description = it.description
-                        offer = it
-                        setLocalDescription(sdp = description, isOffer = true)
-                        sendOffer.invoke(description)
-                    }
-                }
-
-                override fun onSetSuccess() {}
-                override fun onCreateFailure(p0: String?) {}
-                override fun onSetFailure(p0: String?) {}
-            }, constraints
-        )
+            sdpObserver(
+                onCreateSuccess = {
+            it?.let { sessionDescription ->
+                val description = sessionDescription.description
+                offer = sessionDescription
+                setLocalDescription(sdp = description, isOffer = true)
+                sendOffer.invoke(description)
+            }
+        },
+            onSetSuccess = { makingOffer = false },
+            onCreateFailure = { error -> makingOffer = false },
+            onSetFailure = { error -> makingOffer = false }), constraints)
     }
 
     fun setLocalDescription(sdp: String, isOffer: Boolean) {
         val sessionDescription = SessionDescription(
-            if (isOffer) SessionDescription.Type.OFFER else SessionDescription.Type.ANSWER,
-            sdp
+            if (isOffer) SessionDescription.Type.OFFER else SessionDescription.Type.ANSWER, sdp
         )
         peerConnection.setLocalDescription(sdpObserver(), sessionDescription)
     }
 
     fun setRemoteDescription(sdp: String, isOffer: Boolean) {
+        if (isOffer) {
+            val offerCollision =
+                peerConnection.signalingState() != SignalingState.STABLE || makingOffer
+            val ignoreOffer = !isPolite && offerCollision
+
+            if (ignoreOffer) {
+                return
+            }
+
+            if (isPolite && offerCollision) {
+                peerConnection.setLocalDescription(
+                    sdpObserver(onSetSuccess = {
+                    makingOffer = false
+                    setRemoteOfferAfterRollback(sdp)
+                }, onSetFailure = { res ->
+                    makingOffer = false
+                }), SessionDescription(SessionDescription.Type.ROLLBACK, ""))
+                return
+            }
+        }
+
         val sessionDescription = SessionDescription(
-            if (isOffer) SessionDescription.Type.OFFER else SessionDescription.Type.ANSWER,
-            sdp
+            if (isOffer) SessionDescription.Type.OFFER else SessionDescription.Type.ANSWER, sdp
         )
-        peerConnection.setRemoteDescription(sdpObserver(), sessionDescription)
-        isRemoteDiscriptionSet = true
+        peerConnection.setRemoteDescription(
+            sdpObserver(
+                onSetSuccess = {
+                    isRemoteDescriptionSet = true
+                },
+            ), sessionDescription
+        )
     }
 
     fun setIceCandidate(sdp: String, sdpMid: String, sdpMLineIndex: Int) =
@@ -182,11 +195,15 @@ class TogePeerConnection(
             if (!isFinishedOfferAnswerExchange()) {
                 return
             }
-
             createOffer()
         }
 
-        override fun onSignalingChange(p0: PeerConnection.SignalingState?) {}
+        override fun onSignalingChange(p0: PeerConnection.SignalingState?) {
+            if (p0 == SignalingState.STABLE) {
+                makingOffer = false
+            }
+        }
+
         override fun onIceConnectionChange(p0: PeerConnection.IceConnectionState?) {}
         override fun onIceConnectionReceivingChange(p0: Boolean) {}
         override fun onIceGatheringChange(p0: PeerConnection.IceGatheringState?) {}
@@ -217,5 +234,12 @@ class TogePeerConnection(
         override fun onSetFailure(p0: String?) {
             onSetFailure(p0)
         }
+    }
+
+    private fun setRemoteOfferAfterRollback(sdp: String) {
+        val sessionDescription = SessionDescription(SessionDescription.Type.OFFER, sdp)
+        peerConnection.setRemoteDescription(
+            sdpObserver(onSetSuccess = { isRemoteDescriptionSet = true }), sessionDescription
+        )
     }
 }


### PR DESCRIPTION
1. offer 충돌시 처리 코드 추가 
2. peerconnection에서 addtrack시 stram에 담아서 전송(FE는 stream사용)
3.  peerconnection에서 addtrack시 기존의 사용트랙(더미포함)이 존재 할 시 교체하도록 변경