### PR TITLE
FEAT : 재연결 처리 및 실패시 퇴장

### DIFF
--- a/app/src/main/java/example/beechang/together/data/repository/RoomRepositoryImpl.kt
+++ b/app/src/main/java/example/beechang/together/data/repository/RoomRepositoryImpl.kt
@@ -2,17 +2,20 @@ package example.beechang.together.data.repository
 
 import example.beechang.together.data.response.handler.mapSuccessOrProvideError
 import example.beechang.together.data.websocket.RoomDataSource
+import example.beechang.together.data.websocket.WebSocketConnectionState
 import example.beechang.together.domain.data.LocalPreference
 import example.beechang.together.domain.data.TogeError
 import example.beechang.together.domain.data.TogeResult
 import example.beechang.together.domain.data.map
 import example.beechang.together.domain.data.mapToge
 import example.beechang.together.domain.model.RoomCode
+import example.beechang.together.domain.model.RoomConnectionState
 import example.beechang.together.domain.model.RoomParticipant
 import example.beechang.together.domain.model.RoomWaitingMembers
 import example.beechang.together.domain.model.UpdatedRoomParticipant
 import example.beechang.together.domain.repository.RoomRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -100,5 +103,17 @@ class RoomRepositoryImpl @Inject constructor(
         return roomDataSource.receiveRoomNotifyCameraStatus()
             .mapToge { it.toParticipant() }
     }
+
+    override suspend fun receiveRoomConnectionState(): Flow<RoomConnectionState> =
+        roomDataSource.receiveRoomConnectionState().map {
+            when (it) {
+                WebSocketConnectionState.CONNECTED -> RoomConnectionState.CONNECTED
+                WebSocketConnectionState.DISCONNECTED -> RoomConnectionState.DISCONNECTED
+                WebSocketConnectionState.RECONNECTING -> RoomConnectionState.RECONNECTING
+                WebSocketConnectionState.RECONNECTED -> RoomConnectionState.RECONNECTED
+                WebSocketConnectionState.FAILED_RECONNECT -> RoomConnectionState.FAILED_RECONNECT
+                WebSocketConnectionState.PENDING -> RoomConnectionState.PENDING
+            }
+        }
 
 }

--- a/app/src/main/java/example/beechang/together/data/websocket/RoomDataSource.kt
+++ b/app/src/main/java/example/beechang/together/data/websocket/RoomDataSource.kt
@@ -35,4 +35,5 @@ interface RoomDataSource {
     suspend fun receiveRoomUpdatingParticipant(): Flow<TogeResult<RoomNotifyUpdateParticipantResponse>>
     suspend fun receiveRoomNotifyMicStatus(): Flow<TogeResult<RoomNotifyChangingMicStatusResponse>>
     suspend fun receiveRoomNotifyCameraStatus(): Flow<TogeResult<RoomNotifyChangingCameraStatusResponse>>
+    suspend fun receiveRoomConnectionState(): Flow<WebSocketConnectionState>
 }

--- a/app/src/main/java/example/beechang/together/data/websocket/RoomDataSourceImpl.kt
+++ b/app/src/main/java/example/beechang/together/data/websocket/RoomDataSourceImpl.kt
@@ -152,5 +152,8 @@ class RoomDataSourceImpl @Inject constructor(
             resType = RoomNotifyChangingCameraStatusResponse.serializer()
         )
 
+    override suspend fun receiveRoomConnectionState(): Flow<WebSocketConnectionState> =
+        webSocketClient.connectionStateFlow
+
 }
 

--- a/app/src/main/java/example/beechang/together/data/websocket/SocketIOWebSocketClient.kt
+++ b/app/src/main/java/example/beechang/together/data/websocket/SocketIOWebSocketClient.kt
@@ -17,8 +17,11 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeout
@@ -31,6 +34,7 @@ import java.net.SocketTimeoutException
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 
@@ -39,7 +43,8 @@ class SocketIOWebSocketClient @Inject constructor() : WebSocketClient, Coroutine
 
     private var socket: Socket? = null
 
-    override var isConnected = false
+    override var isConnected: Boolean = false
+        get() = _connectionStateFlow.value == WebSocketConnectionState.CONNECTED
 
     private var currentToken: String? = null
 
@@ -49,6 +54,9 @@ class SocketIOWebSocketClient @Inject constructor() : WebSocketClient, Coroutine
         onBufferOverflow = BufferOverflow.DROP_OLDEST
     )
     override val eventFlow: SharedFlow<WebSocketEventResponse> = _eventFlow
+
+    private val _connectionStateFlow = MutableStateFlow(WebSocketConnectionState.PENDING)
+    override val connectionStateFlow: Flow<WebSocketConnectionState> = _connectionStateFlow
 
     private val job = SupervisorJob()
     override val coroutineContext: CoroutineContext = job + Dispatchers.IO
@@ -68,21 +76,15 @@ class SocketIOWebSocketClient @Inject constructor() : WebSocketClient, Coroutine
             }
 
             initializeSocket(token)
-
             val socket = socket ?: return false
-            val resultDeferred = async { getConnectionResult() }
+
+            val isSuccessSocketConnection = async { isSuccessSocketConnection() }
+            listeningEvent()
             socket.connect()
 
-            val result = resultDeferred.await().isSuccess
-            isConnected = result
-
-            if (result) {
-                socket.off()
-                listeningEvent()
-            }
-            return result
+            return isSuccessSocketConnection.await()
         } catch (e: Exception) {
-            isConnected = false
+            _connectionStateFlow.update { WebSocketConnectionState.DISCONNECTED }
             Log.e("SocketIOWebSocketClient", "Error connecting socket: ${e.message}")
             e.printStackTrace()
             return false
@@ -97,7 +99,9 @@ class SocketIOWebSocketClient @Inject constructor() : WebSocketClient, Coroutine
                     it.disconnect()
                     val result = disconnectDeferred.await()
                     it.off()
-                    isConnected = false
+                    if (result) {
+                        _connectionStateFlow.update { WebSocketConnectionState.DISCONNECTED }
+                    }
                     result
                 } else {
                     true
@@ -106,10 +110,23 @@ class SocketIOWebSocketClient @Inject constructor() : WebSocketClient, Coroutine
                 true
             }
         } catch (e: Exception) {
-            isConnected = false
+            _connectionStateFlow.update { WebSocketConnectionState.DISCONNECTED }
             Log.e("SocketIOWebSocketClient", "Error disconnecting socket: ${e.message}")
             e.printStackTrace()
             false
+        }
+    }
+
+    private suspend fun isSuccessSocketConnection(): Boolean = suspendCancellableCoroutine { cont ->
+        socket?.let {
+            it.on(Socket.EVENT_CONNECT) {
+                _connectionStateFlow.update { WebSocketConnectionState.CONNECTED }
+                cont.resume(true)
+            }
+            it.on(Socket.EVENT_DISCONNECT) {
+                _connectionStateFlow.update { WebSocketConnectionState.DISCONNECTED }
+                cont.resume(false)
+            }
         }
     }
 
@@ -220,56 +237,6 @@ class SocketIOWebSocketClient @Inject constructor() : WebSocketClient, Coroutine
         }
         socket?.on(Socket.EVENT_DISCONNECT, listener)
         return deferred.await()
-    }
-
-    private suspend fun getConnectionResult(): Result<Boolean> {
-        val deferred = CompletableDeferred<Result<Boolean>>()
-
-        var connectListenerRef: Emitter.Listener? = null
-        var authErrorListenerRef: Emitter.Listener? = null
-        var connectErrorListenerRef: Emitter.Listener? = null
-
-        fun cleanupAllListeners() {
-            socket?.apply {
-                connectListenerRef?.let { off(Socket.EVENT_CONNECT, it) }
-                authErrorListenerRef?.let { off(SocketEventConstants.AUTH_ERROR, it) }
-                connectErrorListenerRef?.let { off(Socket.EVENT_CONNECT_ERROR, it) }
-            }
-        }
-
-        val connectListener = Emitter.Listener { _ ->
-            isConnected = true
-            cleanupAllListeners()
-            deferred.complete(Result.success(true))
-        }
-
-        connectListenerRef = connectListener
-        val authErrorListener = Emitter.Listener { args ->
-            val error = args.firstOrNull()?.toString() ?: "Unknown auth error"
-            cleanupAllListeners()
-            deferred.complete(Result.failure(Exception("Authentication error: $error")))
-        }
-        authErrorListenerRef = authErrorListener
-
-        val connectErrorListener = Emitter.Listener { args ->
-            val error = args.firstOrNull()?.toString() ?: "Unknown connection error"
-            cleanupAllListeners()
-            deferred.complete(Result.failure(Exception("Connection error: $error")))
-        }
-        connectErrorListenerRef = connectErrorListener
-
-        socket?.apply {
-            on(Socket.EVENT_CONNECT, connectListener)
-            on(SocketEventConstants.AUTH_ERROR, authErrorListener)
-            on(Socket.EVENT_CONNECT_ERROR, connectErrorListener)
-        }
-
-        try {
-            return deferred.await()
-        } catch (e: Exception) {
-            cleanupAllListeners()
-            throw e
-        }
     }
 
     private fun initializeSocket(token: String) {

--- a/app/src/main/java/example/beechang/together/data/websocket/SocketIOWebSocketClient.kt
+++ b/app/src/main/java/example/beechang/together/data/websocket/SocketIOWebSocketClient.kt
@@ -284,8 +284,10 @@ class SocketIOWebSocketClient @Inject constructor() : WebSocketClient, Coroutine
     }
 
     companion object {
-        const val RANDOMIZATION_FACTOR = 0.1 // disconnet 0~1700ms / 0~3400ms / 0~6800ms
-        const val RECONNECTION_DELAY = 200L
-        const val RECONNECTION_ATTEMPTS = 5
+        // 서버 20초 ~ 45초 reconnection 대기
+        // reconnect 350~650ms / 700~1300ms / 1400~2600ms / 2800~5200ms / 5600~10400ms / 11200~20800ms / 22400~41600ms
+        const val RANDOMIZATION_FACTOR = 0.2
+        const val RECONNECTION_DELAY = 400L
+        const val RECONNECTION_ATTEMPTS = 7
     }
 }

--- a/app/src/main/java/example/beechang/together/data/websocket/SocketIOWebSocketClient.kt
+++ b/app/src/main/java/example/beechang/together/data/websocket/SocketIOWebSocketClient.kt
@@ -8,6 +8,7 @@ import example.beechang.together.domain.data.TogeError
 import example.beechang.together.domain.data.TogeResult
 import io.socket.client.Ack
 import io.socket.client.IO
+import io.socket.client.Manager
 import io.socket.client.Socket
 import io.socket.emitter.Emitter
 import kotlinx.coroutines.CompletableDeferred
@@ -79,7 +80,10 @@ class SocketIOWebSocketClient @Inject constructor() : WebSocketClient, Coroutine
             val socket = socket ?: return false
 
             val isSuccessSocketConnection = async { isSuccessSocketConnection() }
-            listeningEvent()
+            launch {
+                setSocketConnectionState()
+                listeningEvent()
+            }
             socket.connect()
 
             return isSuccessSocketConnection.await()
@@ -114,44 +118,6 @@ class SocketIOWebSocketClient @Inject constructor() : WebSocketClient, Coroutine
             Log.e("SocketIOWebSocketClient", "Error disconnecting socket: ${e.message}")
             e.printStackTrace()
             false
-        }
-    }
-
-    private suspend fun isSuccessSocketConnection(): Boolean = suspendCancellableCoroutine { cont ->
-        socket?.let {
-            it.on(Socket.EVENT_CONNECT) {
-                _connectionStateFlow.update { WebSocketConnectionState.CONNECTED }
-                cont.resume(true)
-            }
-            it.on(Socket.EVENT_DISCONNECT) {
-                _connectionStateFlow.update { WebSocketConnectionState.DISCONNECTED }
-                cont.resume(false)
-            }
-        }
-    }
-
-    private fun listeningEvent() {
-        socket?.let { socket ->
-            SocketEventConstants.INCOMING_EVENTS.forEach { eventName ->
-                socket.on(eventName) { args ->
-                    launch {
-                        val data = args.firstOrNull()
-                        val jsonData = when {
-                            data == null -> null
-                            data is String && data.startsWith("{") -> data
-                            else -> {
-                                try {
-                                    JSONObject(data.toString()).toString()
-                                } catch (e: Exception) {
-                                    """{"data":"${data.toString().replace("\"", "\\\"")}"}"""
-                                }
-                            }
-                        }
-                        Log.d("SocketIOWebSocketClient", "Event: $eventName, Data: $jsonData")
-                        _eventFlow.emit(WebSocketEventResponse(eventName, jsonData))
-                    }
-                }
-            }
         }
     }
 
@@ -253,6 +219,68 @@ class SocketIOWebSocketClient @Inject constructor() : WebSocketClient, Coroutine
             currentToken = token
         } catch (e: Exception) {
             throw e
+        }
+    }
+
+    private suspend fun isSuccessSocketConnection(): Boolean = suspendCancellableCoroutine { cont ->
+        socket?.let {
+            it.run {
+                on(Socket.EVENT_CONNECT) {
+                    _connectionStateFlow.update { WebSocketConnectionState.CONNECTED }
+                    cont.resume(true)
+                }
+                on(Socket.EVENT_CONNECT_ERROR) {
+                    _connectionStateFlow.update { WebSocketConnectionState.DISCONNECTED }
+                    cont.resume(false)
+                }
+                on(Socket.EVENT_DISCONNECT) {
+                    _connectionStateFlow.update { WebSocketConnectionState.DISCONNECTED }
+                    cont.resume(false)
+                }
+            }
+        }
+    }
+
+    private fun setSocketConnectionState() {
+        socket?.let {
+            it.run {
+                on(Manager.EVENT_RECONNECT) {
+                    _connectionStateFlow.update { WebSocketConnectionState.RECONNECTED }
+                    _connectionStateFlow.update { WebSocketConnectionState.CONNECTED }
+                }
+                on(Manager.EVENT_RECONNECT_ATTEMPT) {
+                    _connectionStateFlow.update { WebSocketConnectionState.RECONNECTING }
+                }
+                on(Manager.EVENT_RECONNECT_FAILED) {
+                    _connectionStateFlow.update { WebSocketConnectionState.FAILED_RECONNECT }
+                    _connectionStateFlow.update { WebSocketConnectionState.DISCONNECTED }
+                }
+            }
+        }
+    }
+
+    private fun listeningEvent() {
+        socket?.let { socket ->
+            SocketEventConstants.INCOMING_EVENTS.forEach { eventName ->
+                socket.on(eventName) { args ->
+                    launch {
+                        val data = args.firstOrNull()
+                        val jsonData = when {
+                            data == null -> null
+                            data is String && data.startsWith("{") -> data
+                            else -> {
+                                try {
+                                    JSONObject(data.toString()).toString()
+                                } catch (e: Exception) {
+                                    """{"data":"${data.toString().replace("\"", "\\\"")}"}"""
+                                }
+                            }
+                        }
+                        Log.d("SocketIOWebSocketClient", "Event: $eventName, Data: $jsonData")
+                        _eventFlow.emit(WebSocketEventResponse(eventName, jsonData))
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/java/example/beechang/together/data/websocket/SocketIOWebSocketClient.kt
+++ b/app/src/main/java/example/beechang/together/data/websocket/SocketIOWebSocketClient.kt
@@ -10,14 +10,13 @@ import io.socket.client.Ack
 import io.socket.client.IO
 import io.socket.client.Manager
 import io.socket.client.Socket
-import io.socket.emitter.Emitter
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -235,7 +234,10 @@ class SocketIOWebSocketClient @Inject constructor() : WebSocketClient, Coroutine
             it.run {
                 io().on(Manager.EVENT_RECONNECT) {
                     _connectionStateFlow.update { WebSocketConnectionState.RECONNECTED }
-                    _connectionStateFlow.update { WebSocketConnectionState.CONNECTED }
+                    launch {
+                        delay(10)
+                        _connectionStateFlow.update { WebSocketConnectionState.CONNECTED }
+                    }
                 }
                 io().on(Manager.EVENT_RECONNECT_ATTEMPT) {
                     _connectionStateFlow.update { WebSocketConnectionState.RECONNECTING }

--- a/app/src/main/java/example/beechang/together/data/websocket/SocketIOWebSocketClient.kt
+++ b/app/src/main/java/example/beechang/together/data/websocket/SocketIOWebSocketClient.kt
@@ -244,16 +244,15 @@ class SocketIOWebSocketClient @Inject constructor() : WebSocketClient, Coroutine
     private fun setSocketConnectionState() {
         socket?.let {
             it.run {
-                on(Manager.EVENT_RECONNECT) {
+                io().on(Manager.EVENT_RECONNECT) {
                     _connectionStateFlow.update { WebSocketConnectionState.RECONNECTED }
                     _connectionStateFlow.update { WebSocketConnectionState.CONNECTED }
                 }
-                on(Manager.EVENT_RECONNECT_ATTEMPT) {
+                io().on(Manager.EVENT_RECONNECT_ATTEMPT) {
                     _connectionStateFlow.update { WebSocketConnectionState.RECONNECTING }
                 }
-                on(Manager.EVENT_RECONNECT_FAILED) {
+                io().on(Manager.EVENT_RECONNECT_FAILED) {
                     _connectionStateFlow.update { WebSocketConnectionState.FAILED_RECONNECT }
-                    _connectionStateFlow.update { WebSocketConnectionState.DISCONNECTED }
                 }
             }
         }
@@ -285,8 +284,8 @@ class SocketIOWebSocketClient @Inject constructor() : WebSocketClient, Coroutine
     }
 
     companion object {
-        const val RANDOMIZATION_FACTOR = 0.7 // disconnet 0~1700ms / 0~3400ms / 0~6800ms
-        const val RECONNECTION_DELAY = 1000L
+        const val RANDOMIZATION_FACTOR = 0.1 // disconnet 0~1700ms / 0~3400ms / 0~6800ms
+        const val RECONNECTION_DELAY = 200L
         const val RECONNECTION_ATTEMPTS = 5
     }
 }

--- a/app/src/main/java/example/beechang/together/data/websocket/SocketIOWebSocketClient.kt
+++ b/app/src/main/java/example/beechang/together/data/websocket/SocketIOWebSocketClient.kt
@@ -227,15 +227,15 @@ class SocketIOWebSocketClient @Inject constructor() : WebSocketClient, Coroutine
             it.run {
                 on(Socket.EVENT_CONNECT) {
                     _connectionStateFlow.update { WebSocketConnectionState.CONNECTED }
-                    cont.resume(true)
+                    if (cont.isActive) cont.resume(true)
                 }
                 on(Socket.EVENT_CONNECT_ERROR) {
                     _connectionStateFlow.update { WebSocketConnectionState.DISCONNECTED }
-                    cont.resume(false)
+                    if (cont.isActive) cont.resume(false)
                 }
                 on(Socket.EVENT_DISCONNECT) {
                     _connectionStateFlow.update { WebSocketConnectionState.DISCONNECTED }
-                    cont.resume(false)
+                    if (cont.isActive) cont.resume(false)
                 }
             }
         }

--- a/app/src/main/java/example/beechang/together/data/websocket/SocketIOWebSocketClient.kt
+++ b/app/src/main/java/example/beechang/together/data/websocket/SocketIOWebSocketClient.kt
@@ -99,20 +99,12 @@ class SocketIOWebSocketClient @Inject constructor() : WebSocketClient, Coroutine
         return try {
             socket?.let {
                 if (isConnected) {
-                    val disconnectDeferred = async { getResultEventDisconnect() }
                     it.disconnect()
-                    val result = disconnectDeferred.await()
-                    it.off()
-                    if (result) {
-                        _connectionStateFlow.update { WebSocketConnectionState.DISCONNECTED }
-                    }
-                    result
-                } else {
-                    true
                 }
-            } ?: run {
-                true
+                clearSocketIoEvent()
+                _connectionStateFlow.update { WebSocketConnectionState.DISCONNECTED }
             }
+            true
         } catch (e: Exception) {
             _connectionStateFlow.update { WebSocketConnectionState.DISCONNECTED }
             Log.e("SocketIOWebSocketClient", "Error disconnecting socket: ${e.message}")
@@ -195,16 +187,6 @@ class SocketIOWebSocketClient @Inject constructor() : WebSocketClient, Coroutine
         return json.decodeFromString(responseType, jsonObj.toString())
     }
 
-
-    private suspend fun getResultEventDisconnect(): Boolean {
-        val deferred = CompletableDeferred<Boolean>()
-        val listener = Emitter.Listener {
-            deferred.complete(true)
-        }
-        socket?.on(Socket.EVENT_DISCONNECT, listener)
-        return deferred.await()
-    }
-
     private fun initializeSocket(token: String) {
         try {
             val options = IO.Options().apply {
@@ -214,11 +196,18 @@ class SocketIOWebSocketClient @Inject constructor() : WebSocketClient, Coroutine
                 reconnectionDelay = RECONNECTION_DELAY
                 reconnectionAttempts = RECONNECTION_ATTEMPTS
             }
-            socket?.off()
+            clearSocketIoEvent()
             socket = IO.socket(BuildConfig.WEBSOCKET_URL, options)
             currentToken = token
         } catch (e: Exception) {
             throw e
+        }
+    }
+
+    private fun clearSocketIoEvent(){
+        socket?.let {
+            it.off()
+            it.io().off()
         }
     }
 
@@ -252,6 +241,7 @@ class SocketIOWebSocketClient @Inject constructor() : WebSocketClient, Coroutine
                     _connectionStateFlow.update { WebSocketConnectionState.RECONNECTING }
                 }
                 io().on(Manager.EVENT_RECONNECT_FAILED) {
+                    launch { this@SocketIOWebSocketClient.disconnect() }
                     _connectionStateFlow.update { WebSocketConnectionState.FAILED_RECONNECT }
                 }
             }

--- a/app/src/main/java/example/beechang/together/data/websocket/WebSocketClient.kt
+++ b/app/src/main/java/example/beechang/together/data/websocket/WebSocketClient.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.KSerializer
 interface WebSocketClient {
     var isConnected: Boolean
     val eventFlow: Flow<WebSocketEventResponse>
+    val connectionStateFlow: Flow<WebSocketConnectionState>
     suspend fun connect(token: String): Boolean
     suspend fun disconnect(): Boolean
     suspend fun <RESP : Any> emitWithAck(
@@ -20,5 +21,14 @@ interface WebSocketClient {
         request: REQ,
         responseType: KSerializer<RESP>
     ): TogeResult<RESP>
+}
+
+enum class WebSocketConnectionState {
+    CONNECTED,
+    DISCONNECTED,
+    RECONNECTING,
+    RECONNECTED,
+    FAILED_RECONNECT,
+    PENDING
 }
 

--- a/app/src/main/java/example/beechang/together/domain/model/RoomInfo.kt
+++ b/app/src/main/java/example/beechang/together/domain/model/RoomInfo.kt
@@ -42,3 +42,11 @@ data class UpdatedRoomParticipant(
     val updatedUser: UserInfo,
     val isJoined: Boolean = false
 )
+
+enum class RoomConnectionState {
+    CONNECTED,
+    DISCONNECTED,
+    RECONNECTING,
+    RECONNECTED,
+    FAILED_RECONNECT,
+}

--- a/app/src/main/java/example/beechang/together/domain/model/RoomInfo.kt
+++ b/app/src/main/java/example/beechang/together/domain/model/RoomInfo.kt
@@ -49,4 +49,5 @@ enum class RoomConnectionState {
     RECONNECTING,
     RECONNECTED,
     FAILED_RECONNECT,
+    PENDING
 }

--- a/app/src/main/java/example/beechang/together/domain/repository/RoomRepository.kt
+++ b/app/src/main/java/example/beechang/together/domain/repository/RoomRepository.kt
@@ -2,6 +2,7 @@ package example.beechang.together.domain.repository
 
 import example.beechang.together.domain.data.TogeResult
 import example.beechang.together.domain.model.RoomCode
+import example.beechang.together.domain.model.RoomConnectionState
 import example.beechang.together.domain.model.RoomParticipant
 import example.beechang.together.domain.model.RoomWaitingMembers
 import example.beechang.together.domain.model.UpdatedRoomParticipant
@@ -31,4 +32,5 @@ interface RoomRepository {
     suspend fun receiveRoomUpdatingParticipant(): Flow<TogeResult<UpdatedRoomParticipant>>
     suspend fun receiveRoomNotifyMicStatus(): Flow<TogeResult<RoomParticipant>>
     suspend fun receiveRoomNotifyCameraStatus(): Flow<TogeResult<RoomParticipant>>
+    suspend fun receiveRoomConnectionState() : Flow<TogeResult<RoomConnectionState>>
 }

--- a/app/src/main/java/example/beechang/together/domain/repository/RoomRepository.kt
+++ b/app/src/main/java/example/beechang/together/domain/repository/RoomRepository.kt
@@ -32,5 +32,5 @@ interface RoomRepository {
     suspend fun receiveRoomUpdatingParticipant(): Flow<TogeResult<UpdatedRoomParticipant>>
     suspend fun receiveRoomNotifyMicStatus(): Flow<TogeResult<RoomParticipant>>
     suspend fun receiveRoomNotifyCameraStatus(): Flow<TogeResult<RoomParticipant>>
-    suspend fun receiveRoomConnectionState() : Flow<TogeResult<RoomConnectionState>>
+    suspend fun receiveRoomConnectionState(): Flow<RoomConnectionState>
 }

--- a/app/src/main/java/example/beechang/together/domain/usecase/room/ReceiveDisconnectedRoomUseCase.kt
+++ b/app/src/main/java/example/beechang/together/domain/usecase/room/ReceiveDisconnectedRoomUseCase.kt
@@ -1,0 +1,17 @@
+package example.beechang.together.domain.usecase.room
+
+import example.beechang.together.domain.data.TogeResult
+import example.beechang.together.domain.model.RoomConnectionState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
+import javax.inject.Inject
+
+class ReceiveDisconnectedRoomUseCase @Inject constructor(
+    private val receiveRoomConnectionStateUseCase: ReceiveRoomConnectionStateUseCase
+) {
+    suspend operator fun invoke(): Flow<TogeResult<RoomConnectionState>> =
+        receiveRoomConnectionStateUseCase()
+            .filter { result ->
+                result is TogeResult.Success && result.data == RoomConnectionState.FAILED_RECONNECT
+            }
+}

--- a/app/src/main/java/example/beechang/together/domain/usecase/room/ReceiveDisconnectedRoomUseCase.kt
+++ b/app/src/main/java/example/beechang/together/domain/usecase/room/ReceiveDisconnectedRoomUseCase.kt
@@ -1,6 +1,5 @@
 package example.beechang.together.domain.usecase.room
 
-import example.beechang.together.domain.data.TogeResult
 import example.beechang.together.domain.model.RoomConnectionState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
@@ -9,9 +8,9 @@ import javax.inject.Inject
 class ReceiveDisconnectedRoomUseCase @Inject constructor(
     private val receiveRoomConnectionStateUseCase: ReceiveRoomConnectionStateUseCase
 ) {
-    suspend operator fun invoke(): Flow<TogeResult<RoomConnectionState>> =
+    suspend operator fun invoke(): Flow<RoomConnectionState> =
         receiveRoomConnectionStateUseCase()
             .filter { result ->
-                result is TogeResult.Success && result.data == RoomConnectionState.FAILED_RECONNECT
+                result == RoomConnectionState.FAILED_RECONNECT
             }
 }

--- a/app/src/main/java/example/beechang/together/domain/usecase/room/ReceiveRoomConnectionStateUseCase.kt
+++ b/app/src/main/java/example/beechang/together/domain/usecase/room/ReceiveRoomConnectionStateUseCase.kt
@@ -1,6 +1,5 @@
 package example.beechang.together.domain.usecase.room
 
-import example.beechang.together.domain.data.TogeResult
 import example.beechang.together.domain.model.RoomConnectionState
 import example.beechang.together.domain.repository.RoomRepository
 import kotlinx.coroutines.flow.Flow
@@ -9,6 +8,6 @@ import javax.inject.Inject
 class ReceiveRoomConnectionStateUseCase @Inject constructor(
     private val roomRepository: RoomRepository
 ) {
-    suspend operator fun invoke(): Flow<TogeResult<RoomConnectionState>> =
+    suspend operator fun invoke(): Flow<RoomConnectionState> =
         roomRepository.receiveRoomConnectionState()
 }

--- a/app/src/main/java/example/beechang/together/domain/usecase/room/ReceiveRoomConnectionStateUseCase.kt
+++ b/app/src/main/java/example/beechang/together/domain/usecase/room/ReceiveRoomConnectionStateUseCase.kt
@@ -1,0 +1,14 @@
+package example.beechang.together.domain.usecase.room
+
+import example.beechang.together.domain.data.TogeResult
+import example.beechang.together.domain.model.RoomConnectionState
+import example.beechang.together.domain.repository.RoomRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class ReceiveRoomConnectionStateUseCase @Inject constructor(
+    private val roomRepository: RoomRepository
+) {
+    suspend operator fun invoke(): Flow<TogeResult<RoomConnectionState>> =
+        roomRepository.receiveRoomConnectionState()
+}

--- a/app/src/main/java/example/beechang/together/domain/usecase/room/ReceiveRoomDisconnectedUseCase.kt
+++ b/app/src/main/java/example/beechang/together/domain/usecase/room/ReceiveRoomDisconnectedUseCase.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import javax.inject.Inject
 
-class ReceiveDisconnectedRoomUseCase @Inject constructor(
+class ReceiveRoomDisconnectedUseCase @Inject constructor(
     private val receiveRoomConnectionStateUseCase: ReceiveRoomConnectionStateUseCase
 ) {
     suspend operator fun invoke(): Flow<RoomConnectionState> =

--- a/app/src/main/java/example/beechang/together/ui/call/room/CallRoomScreen.kt
+++ b/app/src/main/java/example/beechang/together/ui/call/room/CallRoomScreen.kt
@@ -67,6 +67,7 @@ fun CallRoomRouter(
     var isShowDialogForWrongRoomCode by remember { mutableStateOf(false) }
     var isShowDialogDisconnectRoom by remember { mutableStateOf(false) }
     var isShowDialogPermission by remember { mutableStateOf(false) }
+    var isShowDialogConnectionDisconnected by remember { mutableStateOf(false) }
 
     val permissionHandler =
         rememberMultiPermissionHandler(
@@ -199,8 +200,8 @@ fun CallRoomRouter(
 
     LaunchedEffect(roomViewModel) {
         roomViewModel.errorEffect.collect { error ->
-            if (error is TogeError.FailedToCreateRoom) {
-                //todo show error dialog -> out of room
+            if (error is TogeError.FailedToCreateRoom || error is TogeError.FailedToConnectRoom) {
+                isShowDialogConnectionDisconnected = true
             } else if (error is TogeError.RoomNotFound) {
 
             }
@@ -231,6 +232,7 @@ fun CallRoomRouter(
         isShowParticipantBottomSheet = isShowParticipantBottomSheet,
         isShowDialogForWrongRoomCode = isShowDialogForWrongRoomCode,
         isShowDialogDisconnectRoom = isShowDialogDisconnectRoom,
+        isShowDialogConnectionDisconnected = isShowDialogConnectionDisconnected,
         isShowDialogPermission = isShowDialogPermission,
         /* EVENT */
         onEventDisconnect = {
@@ -242,6 +244,7 @@ fun CallRoomRouter(
         onEventShowDisconnectDialog = { isShowDialogDisconnectRoom = true },
         onEventDismissPermissionDialog = { isShowDialogPermission = false },
         onEventDismissWrongRoomCodeDialog = { isShowDialogForWrongRoomCode = false },
+        onEventDismissConnectionDisconnected = { isShowDialogConnectionDisconnected = false },
         onEventSwitchCamera = { signallingViewModel.onEvent(SwitchCamera) },
         onEventToggleOnOffCamera = handleToggleCamera,
         onEventToggleOnOffMic = handleToggleMic,
@@ -272,6 +275,7 @@ fun CallRoomScreen(
     isSpeakerMuted: Boolean = false,
     isShowParticipantBottomSheet: Boolean = false,
     isShowDialogForWrongRoomCode: Boolean = false,
+    isShowDialogConnectionDisconnected: Boolean = false,
     isShowDialogDisconnectRoom: Boolean = false,
     isShowDialogPermission: Boolean = false,
     /* EVENT */
@@ -280,6 +284,7 @@ fun CallRoomScreen(
     onEventShowDisconnectDialog: () -> Unit = {},
     onEventDismissPermissionDialog: () -> Unit = {},
     onEventDismissWrongRoomCodeDialog: () -> Unit = {},
+    onEventDismissConnectionDisconnected: () -> Unit = {},
     onEventSwitchCamera: () -> Unit = { },
     onEventToggleOnOffCamera: (Boolean) -> Unit = { },
     onEventToggleOnOffMic: (Boolean) -> Unit = { },
@@ -295,6 +300,16 @@ fun CallRoomScreen(
     }
 
     /* DIALOG */
+    TogeOnlyConfirmBtnDialog(
+        isShowDialog = isShowDialogConnectionDisconnected,
+        title = stringResource(R.string.end_call),
+        content = stringResource(R.string.connection_problem),
+        onConfirm = {
+            onEventDisconnect()
+            onEventDismissConnectionDisconnected()
+        }
+    )
+
     TogeOnlyConfirmBtnDialog(
         isShowDialog = isShowDialogForWrongRoomCode,
         title = stringResource(R.string.error),

--- a/app/src/main/java/example/beechang/together/ui/call/room/CallRoomViewModel.kt
+++ b/app/src/main/java/example/beechang/together/ui/call/room/CallRoomViewModel.kt
@@ -8,6 +8,7 @@ import example.beechang.together.domain.data.TogeError
 import example.beechang.together.domain.usecase.room.CreateRoomUseCase
 import example.beechang.together.domain.usecase.room.DecideWaitingEnterFromHostUseCase
 import example.beechang.together.domain.usecase.room.DisconnectRoomUseCase
+import example.beechang.together.domain.usecase.room.ReceiveRoomDisconnectedUseCase
 import example.beechang.together.domain.usecase.room.ReceiveWaitingNotifyUseCase
 import example.beechang.together.ui.utils.BaseViewModel
 import example.beechang.together.ui.utils.UiEffect
@@ -23,6 +24,7 @@ class CallRoomViewModel @Inject constructor(
     private val disconnectRoomUseCase: DisconnectRoomUseCase,
     private val decideWaitingMemberEnterRoomUseCase: DecideWaitingEnterFromHostUseCase,
     private val receiveWaitingNotifyUseCase: ReceiveWaitingNotifyUseCase,
+    private val receiveRoomDisconnectedUseCase: ReceiveRoomDisconnectedUseCase,
     savedStateHandle: SavedStateHandle
 ) : BaseViewModel<CallRoomState, CallRoomEvent, CallRoomEffect>(
     savedStateHandle, CallRoomState(), CALL_ROOM_STATE
@@ -36,6 +38,7 @@ class CallRoomViewModel @Inject constructor(
         }
 
         listeningWaitingNotify()
+        listeningRoomConnectionState()
     }
 
     override fun onEvent(event: CallRoomEvent) {
@@ -106,6 +109,13 @@ class CallRoomViewModel @Inject constructor(
                     updateState { copy(waitingParticipants = waitingList) }
                 }
             )
+    }
+
+    private fun listeningRoomConnectionState() = viewModelScope.launch {
+        receiveRoomDisconnectedUseCase.invoke()
+            .collect {
+                sendError(TogeError.FailedToConnectRoom)
+            }
     }
 
 


### PR DESCRIPTION
1. 재연결 처리 횟수 및 시간 조정
2. reconnection관련 engine.io 이벤트 추가 
3. 웹소켓 상태 및 flow 추가 후 방출
4. ui단에서 연결 실패 알림 받으면 퇴장처리  